### PR TITLE
DYN-2555 - Increase the code coverage: DynamoCore/Search Folder 2

### DIFF
--- a/test/DynamoCoreTests/DynamoCoreTests.csproj
+++ b/test/DynamoCoreTests/DynamoCoreTests.csproj
@@ -125,6 +125,13 @@
     <Compile Include="ProfilingTest.cs" />
     <Compile Include="Search\BrowserInternalElementTest.cs" />
     <Compile Include="Search\BrowserItemTest.cs" />
+    <Compile Include="Search\SearchDictionaryTest.cs" />
+    <Compile Include="Search\SearchElements\CodeBlockNodeSearchElementTest.cs" />
+    <Compile Include="Search\SearchElements\CustomNodeSearchElementTest.cs" />
+    <Compile Include="Search\SearchElements\NodeModelSearchElementTest.cs" />
+    <Compile Include="Search\SearchElements\NodeSearchElementTest.cs" />
+    <Compile Include="Search\SearchElements\SearchElementBaseTest.cs" />
+    <Compile Include="Search\SearchLibraryTest.cs" />
     <Compile Include="SerializationTests.cs" />
     <Compile Include="TestZeroTouchClass.cs" />
     <Compile Include="TypedParametersToStringTests.cs" />
@@ -254,6 +261,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/DynamoCoreTests/Search/SearchDictionaryTest.cs
+++ b/test/DynamoCoreTests/Search/SearchDictionaryTest.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Dynamo.Search;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search
+{
+    [TestFixture]
+    class SearchDictionaryTest
+    {
+        /// <summary>
+        /// This test method will execute several Add methods located in the SearchDictionary class
+        /// void Add(IEnumerable<V> values, string tag, double weight = 1)
+        /// void Add(V value, IEnumerable<string> tags, IEnumerable<double> weights)
+        /// void Add(IEnumerable<V> values, IEnumerable<string> tags, double weight = 1)
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestAddItems()
+        {
+            //Arrange
+            var searchDictionary = new SearchDictionary<string>();
+            var tag1 = Guid.NewGuid().ToString();
+
+            //It will generate the numbers from 1 to 10, starting from 1
+            IEnumerable<string> ranges1 = from value in Enumerable.Range(1, 10)
+                                          select value.ToString();
+
+            //This linq expression will generate 1 tags
+            IEnumerable<string> tags = from value in Enumerable.Range(1, 1)
+                                       select Guid.NewGuid().ToString();
+
+            //This linq expression will generate 20 weights
+            IEnumerable<double> wrongWeights = from value in Enumerable.Range(1, 20)
+                                               select double.Parse(value.ToString());
+
+            //This linq expression will generate 1 value starting from 21
+            IEnumerable<string> values = from value in Enumerable.Range(21, 1)
+                                         select value.ToString();
+
+            //Act
+            //This will execute the method void Add(IEnumerable<V> values, string tag, double weight = 1)
+            searchDictionary.Add(ranges1, tag1);//Add 10 strings
+
+            //This will execute the method internal void Add(IEnumerable<V> values, IEnumerable<string> tags, double weight = 1)
+            searchDictionary.Add(values, tags);//Add 1 string
+
+            //Assert
+            //This will execute the method void Add(V value, IEnumerable<string> tags, IEnumerable<double> weights)
+            //It will fail due that number of tags is different than number of weights
+            Assert.Throws<ArgumentException>(() => searchDictionary.Add("Test", tags, wrongWeights));
+
+
+            //Check that we have 11 items in the dictionary
+            Assert.AreEqual(searchDictionary.NumTags, 11);
+        }
+
+        /// <summary>
+        /// This test method will execute several Remove methods located in the SearchDictionary class
+        /// int Remove(Func<V, bool> removeCondition)
+        /// int Remove(Func<V, bool> valueCondition, Func<string, bool> removeTagCondition)
+        /// bool Remove(V value, string tag)
+        /// int Remove(V value, IEnumerable<string> tags)
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestRemoveItems()
+        {
+            // Arrange
+            var searchDictionary = new SearchDictionary<string>();
+            var tag1 = Guid.NewGuid().ToString();
+
+            //It will generate the numbers from 1 to 10, starting from 1
+            IEnumerable<string> ranges1 = from value in Enumerable.Range(1, 10)
+                                          select value.ToString();
+
+            //It will generate the numbers from 1 to 10, starting from 1
+            IEnumerable<string> tags = from value in Enumerable.Range(1, 2)
+                                       select tag1;
+
+            //Delegate that uses a lamda expression to delete the tag "9" inside the searchDictionary
+            Func<string, bool> selector = str => str.Equals("9");
+
+            //Delegate that uses a lamda expression to delete the tag "8" inside the searchDictionary
+            Func<string, bool> selectorValue = str => str.Equals("8");
+
+            //Delegate that uses a lamda expression to delete the tag "8" inside the searchDictionary
+            Func<string, bool> selectorTag = str => str.Equals(tag1);
+
+            //Act
+            searchDictionary.Add(ranges1, tag1);//Add 10 strings
+
+            //This will execute the method  internal bool Remove(V value, string tag)
+            searchDictionary.Remove("10", tag1);//Remove the value "10"         
+
+            //This will execute the method int Remove(Func<V, bool> removeCondition)
+            searchDictionary.Remove(selector);//Remove the value "9"
+
+            //This will execute the method  internal int Remove(Func<V, bool> valueCondition, Func<string, bool> removeTagCondition)
+            searchDictionary.Remove(selectorValue, selectorTag);//Remove the value 8
+
+            //This will execute the method internal int Remove(V value, IEnumerable<string> tags)
+            searchDictionary.Remove("7", tags);//Remove the value 7
+            int valuesRemoved = searchDictionary.Remove("16", tags);//Value won't be found so it will retung 0
+         
+            //Assert
+            //Check that we have only 7 strings in the dictionary, at the beginning we had 10 but 3 were removed
+            Assert.AreEqual(searchDictionary.NumTags, 6);          
+            Assert.AreEqual(valuesRemoved, 0);//Means that value was't found, the Remove(V value, IEnumerable<string> tags) method returned 0
+        }
+
+        /// <summary>
+        /// This test method will execute several methods for getting info from the SearchDictionary
+        /// IEnumerable<V> ByTag(string tag)
+        /// bool Contains(V a)
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TesGetItems()
+        {
+            // Arrange
+            var searchDictionary = new SearchDictionary<string>();
+            var tag1 = Guid.NewGuid().ToString();
+            var tag2 = Guid.NewGuid().ToString();
+
+            //It will generate the numbers from 1 to 10, starting from 1
+            IEnumerable<string> ranges1 = from value in Enumerable.Range(1, 10)
+                                          select value.ToString();
+
+            //It will generate the numbers from 1 to 10, starting from 1
+            IEnumerable<string> ranges2 = from value in Enumerable.Range(1, 10)
+                                          select value.ToString();
+
+            //Act
+            searchDictionary.Add(ranges1, tag1);//Add 10 strings using the tag1
+            searchDictionary.Add(ranges2, tag2);//Add 10 strings using the tag2
+
+            //This will execute the method internal IEnumerable<V> ByTag(string tag)
+            var ienumTags = searchDictionary.ByTag(tag1);
+
+            var tags = searchDictionary.GetTags("5");//This will return 2 tags
+
+            var weights = searchDictionary.GetWeights("5");//This will return 2 weights
+
+            //Assert
+            //This will validate that the method ByTag returns the 10 strings inserted
+            Assert.AreEqual(ienumTags.Count(), 10);
+
+            //This will validate that the dictionary contains the value "6"
+            Assert.IsTrue(searchDictionary.Contains("6"));//This will execute the method bool Contains(V a)
+
+            //Check that the two different tags are returned for the "5" value
+            Assert.AreEqual(tags.Count(), 2);
+
+            //Check that the two different weights are returned for the "5" value
+            Assert.AreEqual(weights.Count(), 2); 
+        }
+
+        /// <summary>
+        ///  This test method will execute the private static SearchDictionary.ContainsSpecialCharacters method
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestContainsSpecialCharacters()
+        {
+            //Arrange
+            string strSpecial = "test*+-test";//Create a string that has special characters
+            bool containsSpecial = false;
+
+            //Act
+            //Using reflection we execute the private ContainsSpecialCharacters static method 
+            MethodInfo dynMethod = typeof(SearchDictionary<string>).GetMethod("ContainsSpecialCharacters", BindingFlags.NonPublic | BindingFlags.Static);
+            containsSpecial = (bool)dynMethod.Invoke(null, new object[] { strSpecial });
+
+            //Arrange
+            Assert.IsTrue(containsSpecial);//Validate that the string has special characters
+        }
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchElements/CodeBlockNodeSearchElementTest.cs
+++ b/test/DynamoCoreTests/Search/SearchElements/CodeBlockNodeSearchElementTest.cs
@@ -1,0 +1,36 @@
+﻿using Dynamo.Graph.Nodes;
+using Dynamo.Search.SearchElements;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search.SearchElements
+{
+    
+    [TestFixture]
+    class CodeBlockNodeSearchElementTest : DynamoModelTestBase
+    {
+        /// <summary>
+        /// This test method will execute the next method in CodeBlockNodeSearchElement 
+        /// protected override NodeModel ConstructNewNodeModel()
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestCodeBlockNodeSearchNewNodeModel()
+        {
+            //Arrange
+            var cbnData = new TypeLoadData(typeof(CodeBlockNodeModel));
+            var codeBlockSearch = new CodeBlockNodeSearchElement(cbnData, CurrentDynamoModel.LibraryServices);
+            int initialCount = CurrentDynamoModel.SearchModel.NumElements;
+
+            CurrentDynamoModel.SearchModel.Add(codeBlockSearch);
+
+            //Act
+            //This will call the method CodeBlockNodeSearchElement.ConstructNewNodeModel()
+            codeBlockSearch.ProduceNode();
+
+            //Assert
+            //Just validate that the new CodeBlockNodeSearchElement was added correctly
+            Assert.AreEqual(initialCount + 1, CurrentDynamoModel.SearchModel.NumElements);
+        }
+
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchElements/CustomNodeSearchElementTest.cs
+++ b/test/DynamoCoreTests/Search/SearchElements/CustomNodeSearchElementTest.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Search.SearchElements;
+using Moq;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search.SearchElements
+{
+    [TestFixture]
+    class CustomNodeSearchElementTest : DynamoModelTestBase
+    {
+        /// <summary>
+        /// This test method will execute the CustomNodeSearchElement.ConstructNewNodeModel() method
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchConstructNewNodeModel()
+        {
+            //Arrange
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+            const string path = @"C:\temp\graphics.dyn";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElement(moq.Object, dummyInfo1);
+
+            //Act
+            var nodeCreated = dummySearch1.CreateNode();
+
+            //Assert
+            //We are using a Mock for the customNodeManager parameter passed to CustomNodeSearchElement constructor then it will be null
+            Assert.IsNull(nodeCreated);
+        }
+
+        /// <summary>
+        /// This test method will execute the next method/properties in CustomNodeSearchElement class:
+        /// void TryLoadDocumentation()
+        /// IEnumerable<Tuple<string, string>> GenerateInputParameters()
+        /// IEnumerable<string> GenerateOutputParameters()
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchTryLoadDocumentationCustom()
+        {
+            //Arrange
+            string path = Path.Combine(TestDirectory, @"core\CustomNodes\CNDefault.dyf");
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElement(moq.Object, dummyInfo1);
+
+            //Act
+            //Execute the GenerateInputParameters() method
+            List<Tuple<string, string>> inputParameters = dummySearch1.InputParameters as List<Tuple<string, string>>;
+
+            //Execute the GenerateOutputParameters() method
+            List<string> outputParameters = dummySearch1.OutputParameters as List<string>;
+
+            dummySearch1.ProduceNode();
+
+            //Assert
+            //It just validates that the parameters is not null and has at least one element in the list
+            Assert.IsNotNull(inputParameters);
+            Assert.Greater(inputParameters.Count, 0);
+            Assert.IsNotNull(outputParameters);
+            Assert.Greater(outputParameters.Count, 0);
+        }
+
+        /// <summary>
+        /// This test method will execute the TryLoadDocumentation() method and reach the exception section
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchTryLoadDocumentationException()
+        {
+            //Arrange
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+            string path = Path.Combine(TestDirectory, @"core\DoesntExists.dyn");//This dyn file doesn't exist
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElement(moq.Object, dummyInfo1);
+
+            //Act
+            //It generates an exception because the dyn file doesn't exists, the exception is not re-thrown 
+            List<Tuple<string, string>> parameters = dummySearch1.InputParameters as List<Tuple<string, string>>;
+
+            //Assert
+            //It just validates that the parameters is not null and has at least one element in the list
+            Assert.IsNotNull(parameters);
+            Assert.Greater(parameters.Count, 0);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchElements/NodeModelSearchElementTest.cs
+++ b/test/DynamoCoreTests/Search/SearchElements/NodeModelSearchElementTest.cs
@@ -1,0 +1,59 @@
+﻿using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Graph.Workspaces;
+using Dynamo.Search.SearchElements;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search.SearchElements
+{
+    /// <summary>
+    /// This test class was created with the purpose of executing the protected method
+    /// protected override NodeModel ConstructNewNodeModel()
+    /// </summary>
+    public class NodeModelSearchElementDerived : NodeModelSearchElement
+    {
+        internal NodeModelSearchElementDerived(TypeLoadData typeLoadData) : base(typeLoadData)
+        {
+
+        }
+
+        protected override NodeModel ConstructNewNodeModel()
+        {
+            return base.ConstructNewNodeModel();//Calls the ConstructNewNodeModel() method in the base class(NodeModelSearchElement)
+        }
+
+        //Due that ConstructNewNodeModel() method is protected we need to create a public method that call it.
+        public NodeModel NewModel()
+        {
+           return ConstructNewNodeModel();
+        }
+    }
+
+    [TestFixture]
+    class NodeModelSearchElementTest : DynamoModelTestBase
+    {
+        /// <summary>
+        /// This test method will execute the NodeModel ConstructNewNodeModel() method in NodeModelSearchElement
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestNodeModelSearchElement()
+        {
+            //Arrange
+            var symbolData = new TypeLoadData(typeof(Symbol));
+
+            //Act
+            var symbolSearchElement = new NodeModelSearchElementDerived(symbolData)
+            {
+                IsVisibleInSearch = CurrentDynamoModel.CurrentWorkspace is CustomNodeWorkspaceModel
+            };
+
+            //Internally this will execute the ConstructNewNodeModel() through the NodeModelSearchElementDerived class
+            var model = symbolSearchElement.NewModel();
+
+            //Assert
+            //We just check that the model was successfully created
+            Assert.IsNotNull(model);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchElements/NodeSearchElementTest.cs
+++ b/test/DynamoCoreTests/Search/SearchElements/NodeSearchElementTest.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Search.SearchElements;
+using Moq;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search.SearchElements
+{
+    /// <summary>
+    /// This test class was created with the purpose of calling the next methods in the base class(NodeSearchElement)
+    /// IEnumerable<Tuple<string, string>> GenerateInputParameters()
+    /// IEnumerable<string> GenerateOutputParameters()
+    /// </summary>
+    public class CustomNodeSearchElementTest2 : NodeSearchElement
+    {
+        private readonly ICustomNodeSource customNodeManager;
+        private string path;
+
+        public Guid ID { get; private set; }
+
+        public override string CreationName { get { return this.ID.ToString(); } }
+
+        public string Path
+        {
+            get { return path; }
+            private set
+            {
+                if (value == path) return;
+                path = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomNodeSearchElement"/> class.
+        /// </summary>
+        /// <param name="customNodeManager">Custom node manager</param>
+        /// <param name="info">Custom node info</param>
+        public CustomNodeSearchElementTest2(ICustomNodeSource customNodeManager, CustomNodeInfo info)
+        {
+            this.customNodeManager = customNodeManager;
+            inputParameters = new List<Tuple<string, string>>();
+            outputParameters = new List<string>();
+            SyncWithCustomNodeInfo(info);
+        }
+
+        /// <summary>
+        ///     Updates the properties of this search element.
+        /// </summary>
+        /// <param name="info">Actual data of custom node</param>        
+        public void SyncWithCustomNodeInfo(CustomNodeInfo info)
+        {
+            ID = info.FunctionId;
+            Name = info.Name;
+            FullCategoryName = info.Category;
+            Description = info.Description;
+            Path = info.Path;
+            iconName = ID.ToString();
+
+            ElementType = ElementTypes.CustomNode;
+            if (info.IsPackageMember)
+                ElementType |= ElementTypes.Packaged; // Add one more flag.
+        }
+
+        protected override NodeModel ConstructNewNodeModel()
+        {
+            return customNodeManager.CreateCustomNodeInstance(ID);
+        }
+
+        protected override IEnumerable<Tuple<string, string>> GenerateInputParameters()
+        {
+            return base.GenerateInputParameters();
+        }
+
+        protected override IEnumerable<string> GenerateOutputParameters()
+        {
+            return base.GenerateOutputParameters();
+        }
+    }
+    [TestFixture]
+    class NodeSearchElementTest : DynamoModelTestBase
+    {
+        /// <summary>
+        /// This test method will execute the next methods/properties in NodeSearchElement class
+        /// protected virtual void OnItemProduced(NodeModel obj)
+        /// public IEnumerable<Tuple<string, string>> InputParameters
+        /// public IEnumerable<string> OutputParameters
+        /// protected virtual IEnumerable<string> GenerateOutputParameters()
+        /// protected virtual IEnumerable<Tuple<string, string>> GenerateInputParameters()
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestNodeSearchElement()
+        {
+            //Arrange
+            string path = Path.Combine(TestDirectory, @"core\CustomNodes\CNDefault.dyf");
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElementTest2(moq.Object, dummyInfo1);
+
+            //Act
+            //Execute the GenerateInputParameters() method
+            List<Tuple<string, string>> inputParameters = dummySearch1.InputParameters as List<Tuple<string, string>>;
+
+            //Execute the GenerateOutputParameters() method
+            List<string> outputParameters = dummySearch1.OutputParameters as List<string>;
+
+            dummySearch1.ProduceNode();
+
+            //Assert
+            //It just validates that the parameters is not null and has at least one element in the list
+            Assert.IsNotNull(inputParameters);
+            Assert.Greater(inputParameters.Count, 0);
+            Assert.IsNotNull(outputParameters);
+            Assert.Greater(outputParameters.Count, 0);
+
+            //This will execute the Get of the IsVisibleInSearch property
+            Assert.IsTrue(dummySearch1.IsVisibleInSearch);
+        }
+
+        /// <summary>
+        /// This test method was created with the purpose of executing the next methods/properties
+        /// public NodeSearchElement SearchElement
+        /// public DragDropNodeSearchElementInfo(NodeSearchElement searchElement)
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestDragDropNodeSearchElement()
+        {
+            //Arrange
+            string path = Path.Combine(TestDirectory, @"core\CustomNodes\CNDefault.dyf");
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElementTest2(moq.Object, dummyInfo1);
+
+            //Act
+            //This will execute the DragDropNodeSearchElementInfo constructor
+            var dragAndDropElement = new DragDropNodeSearchElementInfo(dummySearch1);
+
+            //Assert
+            //This will execute the Get method of the SearchElement property
+            Assert.IsNotNull(dragAndDropElement.SearchElement);
+        }
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchElements/SearchElementBaseTest.cs
+++ b/test/DynamoCoreTests/Search/SearchElements/SearchElementBaseTest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Dynamo.PackageManager;
+using Dynamo.Search.SearchElements;
+using Greg.Responses;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search.SearchElements
+{
+    [TestFixture]
+    class SearchElementBaseTest
+    {
+        bool bExecuted = false;//This flag will be set to true when the event is raised
+
+        /// <summary>
+        /// This test method will execute the next methods in SearchElementBase class
+        /// public virtual void Execute()
+        /// protected void OnExecuted()
+        /// internal event SearchElementHandler Executed;
+        /// public virtual string CreationName
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestNodeModelSearchElement()
+        {
+            //Arrange
+            var searchElement = new PackageManagerSearchElement(new PackageHeader() { name = "Foo" });
+            searchElement.Executed += SearchElement_Executed; //Subscribe the function to the Executed event
+
+            //Act
+            searchElement.Execute();
+
+            //Assert
+            Assert.AreEqual(searchElement.CreationName,"Foo");//This will execute the Get method of the CreationName property
+            Assert.IsTrue(bExecuted);//This just validates that the Execute event was raised
+        }
+
+        //This method will be execute then the OnExecute() event is called.
+        private void SearchElement_Executed(SearchElementBase ele)
+        {
+            bExecuted = true;
+        }
+    }
+}

--- a/test/DynamoCoreTests/Search/SearchLibraryTest.cs
+++ b/test/DynamoCoreTests/Search/SearchLibraryTest.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Nodes.CustomNodes;
+using Dynamo.Search;
+using Dynamo.Search.SearchElements;
+using Moq;
+using NUnit.Framework;
+
+namespace Dynamo.Tests.Search
+{
+    /// <summary>
+    /// This test class was created in order to have public access to the next protected/private properties:
+    /// protected readonly List<double> keywordWeights
+    /// private readonly ICustomNodeSource customNodeManager
+    /// </summary>
+    public class CustomNodeSearchElementTest : NodeSearchElement
+    {
+        private readonly ICustomNodeSource customNodeManager;
+        private string path;
+
+        public Guid ID { get; private set; }
+
+        public override string CreationName { get { return this.ID.ToString(); } }
+
+        public string Path
+        {
+            get { return path; }
+            private set
+            {
+                if (value == path) return;
+                path = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomNodeSearchElement"/> class.
+        /// </summary>
+        /// <param name="customNodeManager">Custom node manager</param>
+        /// <param name="info">Custom node info</param>
+        public CustomNodeSearchElementTest(ICustomNodeSource customNodeManager, CustomNodeInfo info)
+        {
+            this.customNodeManager = customNodeManager;
+            inputParameters = new List<Tuple<string, string>>();
+            outputParameters = new List<string>();
+            SyncWithCustomNodeInfo(info);
+        }
+
+        /// <summary>
+        ///     Updates the properties of this search element.
+        /// </summary>
+        /// <param name="info">Actual data of custom node</param>        
+        public void SyncWithCustomNodeInfo(CustomNodeInfo info)
+        {
+            ID = info.FunctionId;
+            Name = info.Name;
+            FullCategoryName = info.Category;
+            Description = info.Description;
+            Path = info.Path;
+            iconName = ID.ToString();
+
+            ElementType = ElementTypes.CustomNode;
+            if (info.IsPackageMember)
+                ElementType |= ElementTypes.Packaged; // Add one more flag.
+        }
+
+        protected override NodeModel ConstructNewNodeModel()
+        {
+            return customNodeManager.CreateCustomNodeInstance(ID);
+        }
+
+        public ICollection<double> WeightsCollection
+        {
+            get { return keywordWeights; }
+        }
+
+        public ICustomNodeSource getCustomNodeManager()
+        {
+            return customNodeManager;
+        }
+    }
+
+    [TestFixture]
+    class SearchLibraryTest
+    {
+        private static NodeSearchModel search;
+
+        [SetUp]
+        public void Init()
+        {
+            search = new NodeSearchModel();
+        }
+
+        /// <summary>
+        /// This test method will execute the SearchLibrary.Update(TEntry entry, bool isCategoryChanged = false) method
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchLibraryUpdate()
+        {
+            //Arrange
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+            const string path = @"C:\temp\graphics.dyn";
+            const string newNodeName = "TheTurtle";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var dummySearch1 = new CustomNodeSearchElementTest(null, dummyInfo1);
+            var newInfo = new CustomNodeInfo(guid1, newNodeName, catName, descr, path);
+
+            dummySearch1.SearchKeywords.Add("tag1");
+            dummySearch1.WeightsCollection.Add(10);
+
+            //Act
+            search.Add(dummySearch1);
+            dummySearch1.SyncWithCustomNodeInfo(newInfo);
+            search.Update(dummySearch1);//internal void Update(TEntry entry, bool isCategoryChanged = false)
+            search.Update(dummySearch1,true);
+
+            //Assert
+            //Just validate that the tags and weights were added correctly
+            Assert.AreEqual(dummySearch1.SearchKeywords.Count, 1);
+            Assert.AreEqual(dummySearch1.WeightsCollection.Count, 1);
+        }
+
+        /// <summary>
+        /// This test method will execute the event OnItemProduced from the SearchLibrary class
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchLibraryOnItemProduced()
+        {
+            //Arrange
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat";
+            const string descr = "TheCat";
+            const string path = @"C:\temp\graphics.dyn";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var moq = new Mock<ICustomNodeSource>();
+            var dummySearch1 = new CustomNodeSearchElementTest(moq.Object, dummyInfo1);
+
+            //Act
+            search.Add(dummySearch1);
+            dummySearch1.ProduceNode();//Internally this will execute the event OnItemProduced
+
+            //Assert
+            //Just validate that the OnItemProduced(ConstructNewNodeModel()); method was executed
+            Assert.IsNotNull(dummySearch1.getCustomNodeManager());
+
+            //This will execute the event OnItemProduced when the parameter is null
+            Assert.Throws<NullReferenceException>(() => search.Add(null));
+        }
+
+        /// <summary>
+        /// This test method will execute the SearchCategoryUtil.GetAllCategoryNames method
+        /// </summary>
+        [Test]
+        [Category("UnitTests")]
+        public void TestSearchGetAllCategoryNames()
+        {
+            //Arrange
+            IEnumerable<string> allCategoryNames = null;
+
+            //Arrange
+            const string nodeName = "TheNoodle";
+            const string catName = "TheCat.CatSon";//This will create a Category and Subcategory
+            const string descr = "TheCat";
+            const string path = @"C:\temp\graphics.dyn";
+
+            var guid1 = Guid.NewGuid();
+            var dummyInfo1 = new CustomNodeInfo(guid1, nodeName, catName, descr, path);
+            var dummySearch1 = new CustomNodeSearchElementTest(null, dummyInfo1);
+
+            var searchLibrary = new SearchLibrary<NodeSearchElement, NodeModel>();
+            searchLibrary.Add(dummySearch1);
+
+            //Act
+            var root = SearchCategoryUtil.CategorizeSearchEntries(
+                searchLibrary.SearchEntries,
+                entry => entry.Categories);
+
+            foreach (var category in root.SubCategories)
+            {
+                allCategoryNames = SearchCategoryUtil.GetAllCategoryNames(category);
+            }
+
+            //Assert
+            //Just validate that search entries is not null
+            Assert.IsNotNull(root);
+            //Validate that the GetAllCategoryNames returned at least one element
+            Assert.Greater(allCategoryNames.Count(),0);
+        }
+
+    }
+} 
+


### PR DESCRIPTION
I created several unit tests using nunit and AxoCover (code coverage) for the next classes (some of them already had code coverage) inside Search and SearchElements folders:

### Purpose

DYN-2555 - Increase the code coverage: DynamoCore/Search Folder 2

### Declarations

Check these if you believe they are true

- [ ] The codebase is in a better state after this PR
- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
